### PR TITLE
Update ConfigExtraction to use getPath from method that have this getter instead of parent class Block

### DIFF
--- a/include/Block.hpp
+++ b/include/Block.hpp
@@ -43,6 +43,8 @@ public:
 
     void printBlock(int indent = 0) const;
 
+    virtual void apply(Location& location) = 0;
+
 protected:
     std::stringstream ss;
     bool isValid;
@@ -57,4 +59,4 @@ protected:
 
 private:
     Block();
-};
+}

--- a/include/LocationBlock.hpp
+++ b/include/LocationBlock.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "Block.hpp"
+#include "Location.hpp"
 #include <sstream>
 #include <vector>
 
@@ -25,6 +26,7 @@ public:
 
     void validate();
     const std::vector<std::string>& getPaths() const;
+    void apply(Location& location);
 
 private:
 	void tokenizeName();

--- a/source/block/Block.cpp
+++ b/source/block/Block.cpp
@@ -131,3 +131,8 @@ void Block::extractName()
     std::stringstream ss(fullLine);
     ss >> name;
 }
+
+void Block::apply(Location& location)
+{
+    // This method will be overridden by derived classes
+}

--- a/source/block/LocationBlock.cpp
+++ b/source/block/LocationBlock.cpp
@@ -69,3 +69,10 @@ const std::vector<std::string>& LocationBlock::getPaths() const
 {
 	return paths;
 }
+
+void LocationBlock::apply(Location& location)
+{
+    for (size_t i = 0; i < paths.size(); ++i) {
+        location.addPath(paths[i]);
+    }
+}

--- a/source/parser/ConfigExtractor.cpp
+++ b/source/parser/ConfigExtractor.cpp
@@ -50,10 +50,7 @@ void ConfigExtractor::extractLocationBlocks(const Block& block, Server& server)
 		const Block& subBlock = *subBlocks[i];
 		if (subBlock.getName() == "location") {
 			Location location;
-			const std::vector<std::string>& paths = subBlock.getPaths();
-			for (size_t j = 0; j < paths.size(); ++j) {
-				location.addPath(paths[j]);
-			}
+			subBlock.apply(location);
 			extractLocationDirectives(subBlock, location);
 			server.addLocation(location);
 		}


### PR DESCRIPTION
Update `ConfigExtractor::extractLocationBlocks` to use `apply` method from `LocationBlock` instead of `getPaths`.

* Add a virtual `apply` method to the `Block` class in `include/Block.hpp`.
* Add an `apply` method to the `LocationBlock` class in `include/LocationBlock.hpp` that takes a `Location` object as a parameter.
* Implement the virtual `apply` method in the `Block` class in `source/block/Block.cpp`.
* Implement the `apply` method in the `LocationBlock` class in `source/block/LocationBlock.cpp`.
* Modify `ConfigExtractor::extractLocationBlocks` in `source/parser/ConfigExtractor.cpp` to call the `apply` method of `LocationBlock`.

